### PR TITLE
Make compatible with browserify (CommonJS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"scripts": {
 		"test": "grunt jasmine"
 	},
+	"main": "src/logging.js",
 	"bugs": {
 		"url": "http://github.com/patterns/logging/issues"
 	},

--- a/src/logging.js
+++ b/src/logging.js
@@ -236,6 +236,8 @@
         define("logging", [], function () {
             return api;
         });
+    else if (typeof module !== "undefined" && module.exports)
+        module.exports = api;
     else
         window.logging=api;
 })();


### PR DESCRIPTION
Now this package can be installed with npm (using the git URL), and
used with browserify as `require('logging')`